### PR TITLE
Fixes for MongoDB 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 
-cache: 
-  - pip
-  - apt
-
 python:
   #- "3.2"
   #- "3.3"
@@ -15,7 +11,7 @@ services:
   - elasticsearch
   
 env:
-  - MONGODB_URL=mongodb://localhost/widukind
+  - MONGODB_URL=mongodb://localhost/widukind_test
   
 before_install:
  - "sudo apt-get update -qq"
@@ -33,7 +29,7 @@ before_script:
   - pip freeze
   - java -version
   - mongo --version
-  - curl -XPUT localhost:9200
+  - curl -XGET localhost:9200?pretty
   - curl -XPUT localhost:9200/widukind?pretty
   
 script:

--- a/dlstats/fetchers/_commons.py
+++ b/dlstats/fetchers/_commons.py
@@ -27,29 +27,47 @@ def create_or_update_indexes(db, force_mode=False):
     
     if not force_mode and UPDATE_INDEXES:
         return
+
+    db[constants.COL_PROVIDERS].create_index([
+        ("name", ASCENDING)], 
+        name="name_idx", unique=True)
     
-    db[constants.COL_PROVIDERS].create_indexes([IndexModel([("name", ASCENDING)], name="name_idx", unique=True)]) 
-
-    db[constants.COL_CATEGORIES].create_indexes([
-        IndexModel([("provider", ASCENDING), ("categoryCode", ASCENDING)], name="provider_categoryCode_idx", unique=True),
-    ])
-
+    db[constants.COL_CATEGORIES].create_index([
+        ("provider", ASCENDING), 
+        ("categoryCode", ASCENDING)], 
+        name="provider_categoryCode_idx", unique=True)
+     
     #TODO: lastUpdate DESCENDING ?
-    db[constants.COL_DATASETS].create_indexes([
-        IndexModel([("provider", ASCENDING), ("datasetCode", ASCENDING)], name="provider_datasetCode_idx", unique=True),
-        IndexModel([("name", ASCENDING)], name="name_idx"),
-        IndexModel([("lastUpdate", DESCENDING)], name="lastUpdate_idx"),
-    ])
+    db[constants.COL_DATASETS].create_index([
+            ("provider", ASCENDING), 
+            ("datasetCode", ASCENDING)], 
+            name="provider_datasetCode_idx", unique=True)
+        
+    db[constants.COL_DATASETS].create_index([
+        ("name", ASCENDING)], 
+        name="name_idx")
+    
+    db[constants.COL_DATASETS].create_index([
+        ("lastUpdate", DESCENDING)], 
+        name="lastUpdate_idx")
 
-    db[constants.COL_SERIES].create_indexes([
-        IndexModel([("provider", ASCENDING), 
-                    ("datasetCode", ASCENDING), 
-                    ("key", ASCENDING)], name="provider_datasetCode_key_idx", unique=True),
+    db[constants.COL_SERIES].create_index([
+        ("provider", ASCENDING), 
+        ("datasetCode", ASCENDING), 
+        ("key", ASCENDING)], 
+        name="provider_datasetCode_key_idx", unique=True)
 
-        IndexModel([("key", ASCENDING)], name="key_idx"),
-        IndexModel([("name", ASCENDING)], name="name_idx"),
-        IndexModel([("frequency", DESCENDING)], name="frequency_idx"),
-    ])
+    db[constants.COL_SERIES].create_index([
+        ("key", ASCENDING)], 
+        name="key_idx")
+        
+    db[constants.COL_SERIES].create_index([
+        ("name", ASCENDING)], 
+        name="name_idx")
+    
+    db[constants.COL_SERIES].create_index([
+        ("frequency", DESCENDING)], 
+        name="frequency_idx")
     
     UPDATE_INDEXES = True
 

--- a/dlstats/tests/base.py
+++ b/dlstats/tests/base.py
@@ -11,6 +11,8 @@ from dlstats.tests import utils
 
 RESOURCES_DIR = os.path.abspath(os.path.dirname(resources.__file__))
 
+VERIFIED_RELEASES = False
+
 class BaseTest(unittest.TestCase):
     
     def setUp(self):
@@ -19,6 +21,75 @@ class BaseTest(unittest.TestCase):
 class BaseDBTest(BaseTest):
     """Tests with MongoDB or ElasticSearch
     """
+    
+    def _release_mongodb(self):
+        """Verify MongoDB and pymongo release
+        
+        - http://docs.mongodb.org/ecosystem/drivers/driver-compatibility-reference
+        
+        - pymongo >= 2.8 = mongodb 2.4, 2.6, 3.0
+        - pymongo 2.7 = mongodb 2.4, 2.6
+        - pymongo 2.6 = mongodb 2.4        
+        """
+
+        import pymongo
+
+        # (3, 0, 3)
+        if pymongo.version_tuple[0] < 3:
+            self.fail("Not supported Pymongo [%s] release. Required Pymongo 3.0.x" % pymongo.version)
+
+        server_info = self.db.client.server_info() 
+        server_release = server_info['versionArray'] #'versionArray': [2, 4, 14, 0]}
+        
+        #TODO: server_info['maxBsonObjectSize'] # 16777216
+        #TODO: 'bits': 64,
+                
+        if server_release[0] != 2 or (server_release[0] == 2 and server_release[1] != 4):
+            self.fail("Not supported MongoDB [%s] release. Required MongoDB 2.4.x" % server_info['version'])
+
+    def _release_elasticsearch(self):
+        """Verify Elasticsearch and elasticsearch-py release
+        
+        # Elasticsearch 2.x
+        elasticsearch>=2.0.0,<3.0.0
+        
+        # Elasticsearch 1.x
+        elasticsearch>=1.0.0,<2.0.0
+        
+        # Elasticsearch 0.90.x
+        elasticsearch<1.0.0        
+
+        {'cluster_name': 'elasticsearch',
+         'name': 'Fateball',
+         'status': 200,
+         'tagline': 'You Know, for Search',
+         'version': {'build_hash': 'b88f43fc40b0bcd7f173a1f9ee2e97816de80b19',
+                     'build_snapshot': False,
+                     'build_timestamp': '2015-07-29T09:54:16Z',
+                     'lucene_version': '4.10.4',
+                     'number': '1.7.1'}}
+        """
+        server_info = self.es.info() 
+        server_release = server_info['version']['number']
+        server_release_tuple = server_release.split('.')
+
+        if server_release_tuple[0] != "1" or server_release_tuple[1] not in ["6", "7"]:
+            self.fail("Not supported ElasticSearch Server [%s] release. Required ElasticSearch 1.6.x or 1.7.x" % server_release)
+        
+        from elasticsearch import VERSION #(1, 6, 0)
+        #TODO: required
+            
+    def _releases_verify_ok(self):
+
+        global VERIFIED_RELEASES
+        
+        if VERIFIED_RELEASES:
+            return True
+
+        self._release_mongodb()
+        #TODO: self._release_elasticsearch()
+        
+        VERIFIED_RELEASES = True
 
     def _collections_is_empty(self):
         self.assertEqual(self.db[constants.COL_CATEGORIES].count(), 0)
@@ -28,9 +99,11 @@ class BaseDBTest(BaseTest):
     
     def setUp(self):
         unittest.TestCase.setUp(self)
-
+        
         self.db = utils.get_mongo_db()
         self.es = utils.get_es_db()
+
+        self._releases_verify_ok()
         
         utils.clean_mongodb(self.db)
         utils.clean_es()

--- a/dlstats/tests/fetchers/test__commons.py
+++ b/dlstats/tests/fetchers/test__commons.py
@@ -398,7 +398,30 @@ class DBCategoryTestCase(BaseDBTest):
     
     #TODO: test indexes keys and properties
     def test_indexes(self):
-        pass
+
+        # nosetests -s -v dlstats.tests.fetchers.test__commons:DBCategoryTestCase.test_unique_constraint
+
+        indexes = self.db[constants.COL_CATEGORIES].index_information()
+        
+        self.assertEqual(len(indexes), 2)
+        
+        
+        """
+        >>> pp(c.widukind.providers.index_information())
+
+        {'_id_': {'key': [('_id', 1)], 'ns': 'widukind.providers', 'v': 1},
+         'name_idx': {'key': [('name', 1)],
+                      'ns': 'widukind.providers',
+                      'unique': True,
+                      'v': 1}}        
+        
+        >>> for i in list(c.widukind.datasets.index_information().items()): print(i)
+
+        ('lastUpdate_idx', {'key': [('lastUpdate', -1)], 'v': 1, 'ns': 'widukind.datasets'})
+        ('provider_datasetCode_idx', {'key': [('provider', 1), ('datasetCode', 1)], 'v': 1, 'ns': 'widukind.datasets', 'unique': True})
+        ('name_idx', {'key': [('name', 1)], 'v': 1, 'ns': 'widukind.datasets'})
+        ('_id_', {'key': [('_id', 1)], 'v': 1, 'ns': 'widukind.datasets'})                      
+        """
     
     def test_unique_constraint(self):
 
@@ -448,19 +471,9 @@ class DBCategoryTestCase(BaseDBTest):
                      docHref='http://www.example.com',
                      fetcher=f)
         result = c.update_database()
-        """
-        print(result.matched_count, result.modified_count, result.upserted_id, result.raw_result)
-        > created:
-        0 0 561e4b96f3ceb180160a3db0 
-        {'electionId': ObjectId('56169d19f3ceb180160a3d25'), 'nModified': 0, 'updatedExisting': False, 'ok': 1, 'lastOp': Timestamp(1444826006, 3), 'n': 1, 'upserted': ObjectId('561e4b96f3ceb180160a3db0')}                
-
-        > updated:
-        1 1 None 
-        {'ok': 1, 'electionId': ObjectId('56169d19f3ceb180160a3d25'), 'updatedExisting': True, 'n': 1, 'nModified': 1, 'lastOp': Timestamp(1444825463, 1)}
-        """
         self.assertIsNotNone(result)
         self.assertEqual(result.matched_count, 0)
-        self.assertEqual(result.modified_count, 0)
+        self.assertEqual(result.modified_count, None) #TODO: MongoDB 3.0 - return 0
         self.assertIsNotNone(result.upserted_id)
 
         bson = self.db[constants.COL_CATEGORIES].find_one({"provider": "p1", "categoryCode": "c1"})
@@ -483,6 +496,8 @@ class DBProviderTestCase(BaseDBTest):
         pass
     
     def test_unique_constraint(self):
+
+        # nosetests -s -v dlstats.tests.fetchers.test__commons:DBProviderTestCase.test_unique_constraint
 
         self._collections_is_empty()
 
@@ -524,7 +539,7 @@ class DBProviderTestCase(BaseDBTest):
         self.assertIsNotNone(result)
 
         self.assertEqual(result.matched_count, 0)
-        self.assertEqual(result.modified_count, 0)
+        self.assertEqual(result.modified_count, None) #TODO: MongoDB 3.0 - return 0
         self.assertIsNotNone(result.upserted_id)
 
         bson = self.db[constants.COL_PROVIDERS].find_one({"name": "p1"})
@@ -599,7 +614,7 @@ class DBDatasetTestCase(BaseDBTest):
         #print(result.raw)
 
         self.assertEqual(result.matched_count, 0)
-        self.assertEqual(result.modified_count, 0)
+        self.assertEqual(result.modified_count, None) #TODO: MongoDB 3.0 - return 0
         self.assertIsNotNone(result.upserted_id)
 
         bson = self.db[constants.COL_DATASETS].find_one({"provider": "p1", "datasetCode": "d1"})


### PR DESCRIPTION
- Modification de la création des indexes MongoDB
- Correction de tests
- Ajout d'un contrôle de version mongo requis (dans les tests seulement)