### PR TITLE
Setup.cfg

### DIFF
--- a/dlstats/fetchers/BEA.py
+++ b/dlstats/fetchers/BEA.py
@@ -5,7 +5,7 @@ Created on Thu Sep 10 11:35:26 2015
 @author: salimeh
 """
 
-from dlstats.fetchers._commons import Fetcher, Category, Series, Dataset, Provider, CodeDict, ElasticIndex
+from dlstats.fetchers._commons import Fetcher, Categories, Series, Datasets, Providers, CodeDict, ElasticIndex
 #from make_elastic_index import ElasticIndex
 import urllib
 import xlrd

--- a/dlstats/fetchers/IMF.py
+++ b/dlstats/fetchers/IMF.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from dlstats.fetchers._commons import Fetcher, Category, Series, Dataset, Provider, CodeDict, ElasticIndex
+from dlstats.fetchers._commons import Fetcher, Categories, Series, Datasets, Providers, CodeDict, ElasticIndex
 import urllib
 import xlrd
 import csv

--- a/dlstats/fetchers/_commons.py
+++ b/dlstats/fetchers/_commons.py
@@ -202,12 +202,12 @@ class DlstatsCollection(object):
             lgr.log(log_level,collection + ' ' + bson[key] + ' updated.')
             return result
         
-class Provider(DlstatsCollection):
+class Providers(DlstatsCollection):
     """Abstract base class for providers
     
     Inherit from :class:`DlstatsCollection`
     
-    >>> provider = Provider(name='Eurostat',website='http://ec.europa.eu/eurostat')
+    >>> provider = Providers(name='Eurostat',website='http://ec.europa.eu/eurostat')
     >>> print(provider)
     [('name', 'Eurostat'), ('website', 'http://ec.europa.eu/eurostat')]
     """
@@ -249,12 +249,12 @@ class Provider(DlstatsCollection):
                                             'name', 
                                             self.bson)
                 
-class Category(DlstatsCollection):
+class Categories(DlstatsCollection):
     """Abstract base class for categories
     
     >>> from datetime import datetime
     >>> f = Fetcher(provider_name='Test provider')
-    >>> category = Category(provider='Test provider',name='GDP',
+    >>> category = Categories(provider='Test provider',name='GDP',
     ...                 categoryCode='nama_gdp',
     ...                 children=[bson.objectid.ObjectId.from_datetime(datetime(2014,12,3))],
     ...                 docHref='http://www.perdu.com',
@@ -342,11 +342,11 @@ class Category(DlstatsCollection):
                                             self.bson, 
                                             log_level=logging.DEBUG)
 
-class Dataset(DlstatsCollection):
+class Datasets(DlstatsCollection):
     """Abstract base class for datasets
     
     >>> from datetime import datetime
-    >>> dataset = Dataset('Test provider','nama_gdp_fr')
+    >>> dataset = Datasets('Test provider','nama_gdp_fr')
     >>> print(dataset)
     [('provider_name', 'Test provider'), ('dataset_code', 'nama_gdp_fr')]
     """

--- a/dlstats/fetchers/bis.py
+++ b/dlstats/fetchers/bis.py
@@ -85,7 +85,7 @@ import requests
 
 from dlstats import constants
 from dlstats import logger
-from dlstats.fetchers._commons import Fetcher, Category, Dataset, Provider, SeriesEntry
+from dlstats.fetchers._commons import Fetcher, Categories, Datasets, Providers, SeriesEntry
 
 __all__ = ['BIS']
 
@@ -342,9 +342,9 @@ class BIS(Fetcher):
                          db=db, 
                          es_client=es_client)
         
-        self.provider = Provider(name=self.provider_name, 
-                                 website='http://www.bis.org', 
-                                 fetcher=self)
+        self.provider = Providers(name=self.provider_name, 
+                                  website='http://www.bis.org', 
+                                  fetcher=self)
 
     def upsert_dataset(self, dataset_code, datas=None):
         
@@ -356,11 +356,11 @@ class BIS(Fetcher):
             raise Exception("This dataset is unknown" + dataset_code)
         
         #TODO: faire un DatasetBis pour inclure le Downloader à l'init comme callback ?
-        dataset = Dataset(provider_name=self.provider_name, 
-                          dataset_code=dataset_code, 
-                          name=DATASETS[dataset_code]['name'], 
-                          doc_href=DATASETS[dataset_code]['doc_href'],
-                          fetcher=self)
+        dataset = Datasets(provider_name=self.provider_name, 
+                           dataset_code=dataset_code, 
+                           name=DATASETS[dataset_code]['name'], 
+                           doc_href=DATASETS[dataset_code]['doc_href'],
+                           fetcher=self)
         
         fetcher_data = BIS_Data(dataset, 
                                 url=DATASETS[dataset_code]['url'], 
@@ -387,11 +387,11 @@ class BIS(Fetcher):
     def upsert_categories(self):
         
         for dataset_code in DATASETS.keys():
-            document = Category(provider=self.provider_name, 
-                                name=DATASETS[dataset_code]['name'], 
-                                categoryCode=dataset_code,
-                                exposed=True,
-                                fetcher=self)
+            document = Categories(provider=self.provider_name, 
+                                  name=DATASETS[dataset_code]['name'], 
+                                  categoryCode=dataset_code,
+                                  exposed=True,
+                                  fetcher=self)
             
             #TODO: attention, plus de retour du result pymongo
             document.update_database()                            

--- a/dlstats/fetchers/eurostat.py
+++ b/dlstats/fetchers/eurostat.py
@@ -31,7 +31,7 @@ import zipfile
 import pprint
 import bson
 
-from dlstats.fetchers._commons import Fetcher, Category, Series, Dataset, Provider, CodeDict, ElasticIndex
+from dlstats.fetchers._commons import Fetcher, Categories, Series, Datasets, Providers, CodeDict, ElasticIndex
 
 __all__ = ['Eurostat']
 

--- a/dlstats/fetchers/insee.py
+++ b/dlstats/fetchers/insee.py
@@ -1,6 +1,6 @@
 # test limitation on line 98
 
-from dlstats.fetchers._commons import Fetcher, Category, Series, Dataset, Provider, CodeDict, ElasticIndex
+from dlstats.fetchers._commons import Fetcher, Categories, Series, Datasets, Providers, CodeDict, ElasticIndex
 from bs4 import BeautifulSoup
 import urllib.request
 import urllib.parse

--- a/dlstats/fetchers/world_bank.py
+++ b/dlstats/fetchers/world_bank.py
@@ -1,5 +1,5 @@
 
-from dlstats.fetchers._commons import Fetcher, Category, Series, Dataset, Provider, CodeDict, ElasticIndex
+from dlstats.fetchers._commons import Fetcher, Categories, Series, Datasets, Providers, CodeDict, ElasticIndex
 import io
 import zipfile
 import urllib.request

--- a/dlstats/tests/fetchers/test__commons.py
+++ b/dlstats/tests/fetchers/test__commons.py
@@ -13,9 +13,9 @@ from dlstats import constants
 from dlstats.fetchers._commons import (Fetcher, 
                                        CodeDict, 
                                        DlstatsCollection, 
-                                       Provider,
-                                       Category, 
-                                       Dataset, 
+                                       Providers,
+                                       Categories, 
+                                       Datasets, 
                                        Series,
                                        SeriesEntry)
 
@@ -23,7 +23,7 @@ import unittest
 
 from dlstats.tests.base import BaseTest, BaseDBTest, RESOURCES_DIR
 
-class FakeDataset(Dataset):
+class FakeDataset(Datasets):
     
     def download(self, urls):
         """Download all sources for this Dataset
@@ -33,7 +33,7 @@ class FakeDataset(Dataset):
         :return: :class:`dict`
         
         >>> fetcher = Fetcher(provider_name="test")
-        >>> dataset = Dataset(fetcher=fetcher)
+        >>> dataset = Datasets(fetcher=fetcher)
         >>> urls = ['http://localhost/file1.zip', http://localhost/file2.zip']
         >>> dataset.download(urls)
         {
@@ -65,7 +65,7 @@ class FakeDatas():
         f = Fetcher(provider_name="p1", 
                     db=self.db, es_client=self.es)
         
-        d = Dataset(provider_name="p1", 
+        d = Datasets(provider_name="p1", 
                     dataset_code="d1",
                     name="d1 Name",
                     last_update=datetime.now(),
@@ -219,14 +219,14 @@ class CategoryTestCase(BaseTest):
         # nosetests -s -v dlstats.tests.fetchers.test__commons:CategoryTestCase.test_constructor
         
         with self.assertRaises(ValueError):
-            Category()
+            Categories()
                     
         f = Fetcher(provider_name="p1")
 
         with self.assertRaises(MultipleInvalid):
-            Category(fetcher=f)
+            Categories(fetcher=f)
         
-        c = Category(provider="p1", 
+        c = Categories(provider="p1", 
                      name="cat1", 
                      categoryCode="c1",
                      docHref='http://www.example.com',
@@ -250,14 +250,14 @@ class ProviderTestCase(BaseTest):
         # nosetests -s -v dlstats.tests.fetchers.test__commons:ProviderTestCase.test_constructor
 
         with self.assertRaises(ValueError):
-            Provider()
+            Providers()
             
         f = Fetcher(provider_name="p1")            
 
         with self.assertRaises(MultipleInvalid):
-            Provider(fetcher=f)
+            Providers(fetcher=f)
                 
-        p = Provider(name="p1", 
+        p = Providers(name="p1", 
                      website="http://www.example.com", 
                      fetcher=f)
         
@@ -275,11 +275,11 @@ class DatasetTestCase(BaseTest):
         # nosetests -s -v dlstats.tests.fetchers.test__commons:DatasetTestCase.test_constructor
         
         with self.assertRaises(ValueError):
-            Dataset(is_load_previous_version=False)
+            Datasets(is_load_previous_version=False)
             
         f = Fetcher(provider_name="p1")
                 
-        d = Dataset(provider_name="p1", 
+        d = Datasets(provider_name="p1", 
                     dataset_code="d1",
                     name="d1 Name",
                     doc_href="http://www.example.com",
@@ -434,7 +434,7 @@ class DBCategoryTestCase(BaseDBTest):
     
         f = Fetcher(provider_name="p1", db=self.db, es_client=self.es)
         
-        c = Category(provider="p1", 
+        c = Categories(provider="p1", 
                      name="cat1", 
                      categoryCode="c1",
                      docHref='http://www.example.com',
@@ -448,7 +448,7 @@ class DBCategoryTestCase(BaseDBTest):
             existing_category = dict(provider="p1", categoryCode="c1")
             self.db[constants.COL_CATEGORIES].insert(existing_category)
 
-        c = Category(provider="p1", 
+        c = Categories(provider="p1", 
                      name="cat2", 
                      categoryCode="c2",
                      fetcher=f)
@@ -468,7 +468,7 @@ class DBCategoryTestCase(BaseDBTest):
     
         f = Fetcher(provider_name="p1", db=self.db, es_client=self.es)
         
-        c = Category(provider="p1", 
+        c = Categories(provider="p1", 
                      name="cat1", 
                      categoryCode="c1",
                      docHref='http://www.example.com',
@@ -507,7 +507,7 @@ class DBProviderTestCase(BaseDBTest):
         f = Fetcher(provider_name="p1", 
                     db=self.db, es_client=self.es)
 
-        p = Provider(name="p1", 
+        p = Providers(name="p1", 
                      website="http://www.example.com", 
                      fetcher=f)
         p.update_database()
@@ -519,7 +519,7 @@ class DBProviderTestCase(BaseDBTest):
         with self.assertRaises(DuplicateKeyError):
             self.db[constants.COL_PROVIDERS].insert(existing_provider)
 
-        p = Provider(name="p2", 
+        p = Providers(name="p2", 
                      website="http://www.example.com",
                      fetcher=f)
         p.update_database()
@@ -535,7 +535,7 @@ class DBProviderTestCase(BaseDBTest):
         f = Fetcher(provider_name="p1", 
                     db=self.db, es_client=self.es)
 
-        p = Provider(name="p1", 
+        p = Providers(name="p1", 
                      website="http://www.example.com", 
                      fetcher=f)
         result = p.update_database()
@@ -566,7 +566,7 @@ class DBDatasetTestCase(BaseDBTest):
         f = Fetcher(provider_name="p1", 
                     db=self.db, es_client=self.es)
 
-        d = Dataset(provider_name="p1", 
+        d = Datasets(provider_name="p1", 
                     dataset_code="d1",
                     name="d1 Name",
                     last_update=datetime.now(),
@@ -599,7 +599,7 @@ class DBDatasetTestCase(BaseDBTest):
         f = Fetcher(provider_name="p1", 
                     db=self.db, es_client=self.es)
 
-        d = Dataset(provider_name="p1", 
+        d = Datasets(provider_name="p1", 
                     dataset_code="d1",
                     name="d1 Name",
                     last_update=datetime.now(),

--- a/dlstats/tests/fetchers/test_bis.py
+++ b/dlstats/tests/fetchers/test_bis.py
@@ -10,7 +10,7 @@ import urllib.request
 from urllib.parse import urlparse
 from urllib.request import url2pathname, pathname2url
 
-from dlstats.fetchers._commons import Dataset
+from dlstats.fetchers._commons import Datasets
 from dlstats.fetchers import bis
 from dlstats import constants
 
@@ -178,7 +178,7 @@ def load_fake_datas(select_dataset_code=None):
         if select_dataset_code and select_dataset_code != dataset_code:
             continue
         
-        _dataset = Dataset(provider_name=bis.PROVIDER_NAME, 
+        _dataset = Datasets(provider_name=bis.PROVIDER_NAME, 
                     dataset_code=dataset_code, 
                     name=dataset['name'], 
                     doc_href=dataset['doc_href'], 
@@ -354,11 +354,11 @@ class BISDatasetsDBTestCase(BaseDBFetcherTestCase):
         self.assertIsNotNone(category)
         
         #Patch self.fetcher.upsert_dataset('LBS-DISS') - start
-        dataset = Dataset(provider_name=self.fetcher.provider_name, 
-                          dataset_code=self.dataset_code, 
-                          name=DATASETS[self.dataset_code]['name'], 
-                          doc_href=DATASETS[self.dataset_code]['doc_href'], 
-                          fetcher=self.fetcher)
+        dataset = Datasets(provider_name=self.fetcher.provider_name, 
+                           dataset_code=self.dataset_code, 
+                           name=DATASETS[self.dataset_code]['name'], 
+                           doc_href=DATASETS[self.dataset_code]['doc_href'], 
+                           fetcher=self.fetcher)
 
         # manual Data for iterator
         fetcher_data = bis.BIS_Data(dataset, 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ cover-html = 1
 cover-html-dir = ../coverage/htmlcov
 cover-package = dlstats
 where = dlstats
-with-coverage = 0
+#with-coverage = 0
 
 [coverage:run]
 data_file = .coverage


### PR DESCRIPTION
nosetest-3.4 doesn't honor with-coverage=0. The option should simply be removed from setup.cfg
If this the same on everybody's installation, please, pull this pull request.
